### PR TITLE
Include glacier and freeze in jar

### DIFF
--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -74,6 +74,8 @@
         <unjar dest="${target.dir}/generated-classes">
             <fileset dir="${target.dir}/libs">
                 <include name="ice*.jar"/>
+                <include name="glacier*.jar"/>
+                <include name="freeze*.jar"/>
                 <include name="ome-xml.jar"/>
             </fileset>
         </unjar>


### PR DESCRIPTION
The jars no longer start with "ice" so there were not picked up

This includes glacier and freeze

We can review the usage of freeze at another stage. This PR brings it back to the actual status